### PR TITLE
Add root mode fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ go build ./...
 
 The frontend files are ignored from version control, so running the above steps
 before `go build` ensures `web/dist` exists for Go's embed directives.
+
+## Running as root
+
+Chrome refuses to start as the `root` user unless the `--no-sandbox` flag is
+provided. `gowitness` automatically sets this flag when running with UID 0. If
+Chrome still fails to launch, run the tool as a normal user instead.
+
+When not running as root, ensure the screenshot and database paths are writable.
+The program now attempts a small write in the screenshot directory during
+startup and will error if permissions are insufficient.

--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -1,15 +1,16 @@
 package chrome
 
 import (
-	"context"
-	"crypto/tls"
-	"encoding/base64"
-	"errors"
-	"io"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
+        "context"
+        "crypto/tls"
+        "encoding/base64"
+        "errors"
+        "io"
+        "net/http"
+        "net/url"
+        "os"
+        "strings"
+        "time"
 
 	"github.com/chikamim/nilsimsa"
 	"github.com/chromedp/cdproto/inspector"
@@ -292,7 +293,11 @@ func (chrome *Chrome) Screenshot(url *url.URL) (result *ScreenshotResult, err er
 	options = append(options, chromedp.UserAgent(chrome.UserAgent))
 	options = append(options, chromedp.DisableGPU)
 	options = append(options, chromedp.Flag("ignore-certificate-errors", true)) // RIP shittyproxy.go
-	options = append(options, chromedp.WindowSize(chrome.ResolutionX, chrome.ResolutionY))
+        options = append(options, chromedp.WindowSize(chrome.ResolutionX, chrome.ResolutionY))
+
+        if os.Geteuid() == 0 {
+                options = append(options, chromedp.Flag("no-sandbox", true))
+        }
 
 	if chrome.ChromePath != "" {
 		options = append(options, chromedp.ExecPath(chrome.ChromePath))

--- a/lib/options.go
+++ b/lib/options.go
@@ -1,9 +1,10 @@
 package lib
 
 import (
-	"os"
+        "os"
+        "path/filepath"
 
-	"github.com/rs/zerolog"
+        "github.com/rs/zerolog"
 )
 
 // Options contains all of the gowitness options
@@ -74,11 +75,17 @@ func NewOptions() *Options {
 // PrepareScreenshotPath prepares the path to save screenshots in
 func (opt *Options) PrepareScreenshotPath() error {
 
-	if _, err := os.Stat(opt.ScreenshotPath); os.IsNotExist(err) {
-		if err = os.Mkdir(opt.ScreenshotPath, 0750); err != nil {
-			return err
-		}
-	}
+        if _, err := os.Stat(opt.ScreenshotPath); os.IsNotExist(err) {
+                if err = os.Mkdir(opt.ScreenshotPath, 0750); err != nil {
+                        return err
+                }
+        }
 
-	return nil
+        testFile := filepath.Join(opt.ScreenshotPath, ".perm_check")
+        if err := os.WriteFile(testFile, []byte{}, 0600); err != nil {
+                return err
+        }
+        os.Remove(testFile)
+
+        return nil
 }


### PR DESCRIPTION
## Summary
- handle running Chrome as root with `--no-sandbox`
- validate screenshot path is writable on startup
- document running as root

## Testing
- `go vet ./...` *(fails: pattern web/dist contains no embeddable files)*
- `go test ./...` *(fails: cannot embed directory web/dist)*

------
https://chatgpt.com/codex/tasks/task_e_6876bff1d35c832286d269ea042adca0